### PR TITLE
Add note about entire server-wide bans in chats

### DIFF
--- a/mimi-transport-requirements.md
+++ b/mimi-transport-requirements.md
@@ -111,6 +111,8 @@ Similarly, the requirements below describe the expected information sharing when
 - How all of the above works for DMs
 - Whether the authorization rules are enforced by the providers, the clients, or both
 
+Though not supported by DMA gatekeepers, being able to ban entire providers/servers from a chat may be needed.
+
 Based on lack of feature support in existing systems, I think we can leave the rest of the admin features out of scope for now.]
 
 ### 3.5 MLS-Level Access Control


### PR DESCRIPTION
This is likely not required under DMA guidance, but becomes slightly more appealing when a provider wants to reduce the chances of information leaks. For example, if a chat between two providers/servers cannot leave those two servers for legal or security reasons, the chat may wish to ban all other servers from even being able to participate, thus those servers can't receive the room's events (at least at the technological level).

A similar case applies to public-ish chats: those chats may wish to ban malicious servers from participating.